### PR TITLE
chore(release): set `package.json` to 1.1.4 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.1.5](https://github.com/CaptMoar-toctoc/ds/compare/v1.1.4...v1.1.5) (2022-09-05)
+
+
+### Bug Fixes
+
+* **beta:** se quita el log ([21d7c04](https://github.com/CaptMoar-toctoc/ds/commit/21d7c04784f68868215fc25b74e13c5a7ec81882))
 
 ## [1.1.4-beta.2](https://github.com/CaptMoar-toctoc/ds/compare/v1.1.4-beta.1...v1.1.4-beta.2) (2022-09-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.4](https://github.com/CaptMoar-toctoc/ds/compare/v1.1.3...v1.1.4) (2022-09-05)
+
+
+### Bug Fixes
+
+* **commitlint:** se eliminan ramas que no existen 4 ([7501f86](https://github.com/CaptMoar-toctoc/ds/commit/7501f869046216925132bc13fe78016308b2c499))
+
 ## [1.1.3](https://github.com/CaptMoar-toctoc/ds/compare/v1.1.2...v1.1.3) (2022-09-05)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@captmoar-toctoc/ds",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "scripts": {
     "rollup": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@captmoar-toctoc/ds",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "",
   "scripts": {
     "rollup": "rollup -c",


### PR DESCRIPTION
## [1.1.4](https://github.com/CaptMoar-toctoc/ds/compare/v1.1.3...v1.1.4) (2022-09-05)

### Bug Fixes

* **commitlint:** se eliminan ramas que no existen 4 ([7501f86](https://github.com/CaptMoar-toctoc/ds/commit/7501f869046216925132bc13fe78016308b2c499))